### PR TITLE
Optimize logging for journald

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Crataegus is built to ingest history from [GPSLogger](https://gpslogger.app), wh
 - REST API: WIP
 
 ## To Do (for now)
+- add an info command
 - Documentation
 - network locations from GpsLogger will be in MSL
 - get rid of unwrap / graceful error handling


### PR DESCRIPTION
Timestamps are redundant when running under systemd without journal logging enabled. Turn those off and reformat to keep log level and module/lin number. Level-based coloring is also retained to make it easier to read when running in CLI.

Sample:
```
[DEBUG] sqlx_core::logger:143
summary="PRAGMA foreign_keys = ON; …" db.statement="\n\nPRAGMA foreign_keys = ON; \n" rows_affected=0 rows_returned=0 elapsed=45.452µs elapsed_secs=4.5452e-5
[DEBUG] sqlx_core::logger:143
summary="CREATE TABLE IF NOT …" db.statement="\n\nCREATE TABLE IF NOT EXISTS \"users\" ( \"username\" varchar NOT NULL PRIMARY KEY, \"password\" varchar NOT NULL )\n" rows_affected=0 rows_returned=0 elapsed=192.595µs elapsed_secs=0.000192595
[DEBUG] sqlx_core::logger:143
summary="CREATE TABLE IF NOT …" db.statement="\n\nCREATE TABLE IF NOT EXISTS \"locations\" ( \"username\" varchar NOT NULL, \"time_utc\" timestamp_with_timezone_text NOT NULL, \"time_local\" timestamp_with_timezone_text NOT NULL, \"latitude\" double NOT NULL, \"longitude\" double NOT NULL, \"altitude\" double NOT NULL, \"accuracy\" float, \"source\" varchar(32) NOT NULL, CONSTRAINT \"pk-locations\" PRIMARY KEY (\"username\", \"time_utc\"), FOREIGN KEY (\"username\") REFERENCES \"users\" (\"username\") ON DELETE CASCADE ON UPDATE CASCADE )\n" rows_affected=0 rows_returned=0 elapsed=29.48µs elapsed_secs=2.948e-5
[DEBUG] sqlx_core::logger:143
summary="SELECT \"locations\".\"username\", \"locations\".\"time_utc\", \"locations\".\"time_local\", …" db.statement="\n\nSELECT \"locations\".\"username\", \"locations\".\"time_utc\", \"locations\".\"time_local\", \"locations\".\"latitude\", \"locations\".\"longitude\", \"locations\".\"altitude\", \"locations\".\"accuracy\", \"locations\".\"source\" FROM \"locations\" WHERE \"locations\".\"username\" = ? AND (\"locations\".\"time_utc\" BETWEEN ? AND ?) ORDER BY \"locations\".\"time_utc\" ASC\n" rows_affected=0 rows_returned=726 elapsed=12.101956ms elapsed_secs=0.012101956
